### PR TITLE
Cambio en nombre de Archivo

### DIFF
--- a/codegen_Odoov8.py
+++ b/codegen_Odoov8.py
@@ -396,7 +396,7 @@ from openerp import api, fields, models
         zip = zipfile.ZipFile(self.filename, 'w')
         filewrite = {
                 '__init__.py':self.init_get(),
-                '__openerp__.py':self.terp_get(),
+                '__manifest__.py':self.terp_get(),
                 'models/__init__.py':self.init_model_get(),
                 'models/'+module+'.py': self.code_get(),
                 'views/'+module+'_view.xml': self.view_get(),


### PR DESCRIPTION
Se cambia el nombre del archivo __openerp__.py por __manifest__.py, pues en odoo ya no existe openerp